### PR TITLE
mouseable textedit and block mouse on dialogs

### DIFF
--- a/src/ltui/dialog.lua
+++ b/src/ltui/dialog.lua
@@ -63,6 +63,9 @@ function dialog:init(name, bounds, title)
         self:buttons():bounds_set(rect:new(0, v:height() - 1, v:width(), 1))
         self:_update_buttons_layout()
     end)
+
+    -- mark as block mouse
+    self:option_set("blockmouse", true)
 end
 
 -- get buttons

--- a/src/ltui/panel.lua
+++ b/src/ltui/panel.lua
@@ -58,7 +58,7 @@ function panel:init(name, bounds)
 
         -- try focused first
         local current = v:current()
-        if current and current:option("mouseable") and current:bounds():contains(x, y) then
+        if current and current:option("mouseable") and (current:option("blockmouse") or current:bounds():contains(x, y)) then
             return current:action_on(action.ac_on_clicked, x, y)
         end
 

--- a/src/ltui/textedit.lua
+++ b/src/ltui/textedit.lua
@@ -26,6 +26,7 @@ local event     = require("ltui/event")
 local border    = require("ltui/border")
 local curses    = require("ltui/curses")
 local textarea  = require("ltui/textarea")
+local action    = require("ltui/action")
 
 -- define module
 local textedit = textedit or textarea()
@@ -41,6 +42,10 @@ function textedit:init(name, bounds, text)
 
     -- mark as selectable
     self:option_set("selectable", true)
+
+    -- mark as mouseable
+    self:option_set("mouseable", true)
+    self:action_set(action.ac_on_clicked, function () return true end)
 
     -- disable progress
     self:option_set("progress", false)


### PR DESCRIPTION
 Changes to be committed:
	modified:   src/ltui/dialog.lua
	modified:   src/ltui/panel.lua
	modified:   src/ltui/textedit.lua

makes textedit selectable by mouse and grabs mouse events on dialogs
this prevents user selecting views in the background of the focused
dialog, causing errors.

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

