### PR TITLE
Fix the module filename on mingw

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -130,6 +130,10 @@ target("ltui")
         add_shflags("-undefined suppress")
     end
 
+    if is_plat("mingw") then
+        set_filename("ltui.dll")
+    end
+
 -- add projects
 includes("src/core/curses")
 if is_plat("windows") then


### PR DESCRIPTION
```sh
$ xmake run test dialog
lua: ./src/ltui/curses.lua:22: module 'ltui.lcurses' not found:
        no field package.preload['ltui.lcurses']
        no file 'C:\msys64\mingw64\bin\..\share\lua\5.4\ltui\lcurses.lua'
        no file 'C:\msys64\mingw64\bin\..\share\lua\5.4\ltui\lcurses\init.lua'
        no file 'C:\msys64\mingw64\bin\..\lib\lua\5.4\ltui\lcurses.lua'
        no file 'C:\msys64\mingw64\bin\..\lib\lua\5.4\ltui\lcurses\init.lua'
        no file '.\ltui\lcurses.lua'
        no file '.\ltui\lcurses\init.lua'
        no file './src/ltui\lcurses.lua'
        no file 'C:\msys64\mingw64\bin\..\lib\lua\5.4\ltui\lcurses.dll'
        no file 'C:\msys64\mingw64\bin\..\lib\lua\5.4\loadall.dll'
        no file '.\ltui\lcurses.dll'
        no file './build/ltui.dll'
        no file './build/libltui.so'
        no file './build/libltui.dylib'
        no file 'C:\msys64\mingw64\bin\..\lib\lua\5.4\ltui.dll'
        no file 'C:\msys64\mingw64\bin\..\lib\lua\5.4\loadall.dll'
        no file '.\ltui.dll'
        no file './build/ltui.dll'
        no file './build/libltui.so'
        no file './build/libltui.dylib'
stack traceback:
        [C]: in function 'require'
        ./src/ltui/curses.lua:22: in main chunk
        [C]: in function 'require'
        ./src/ltui/application.lua:26: in main chunk
        [C]: in function 'require'
        ./src/ltui.lua:26: in main chunk
        [C]: in function 'require'
        tests\dialog.lua:27: in main chunk
        [C]: in ?
error: execv(lua tests\dialog.lua) failed(1)
```
